### PR TITLE
Performance optimisation of datetime parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>org.pojava</groupId>
     <artifactId>datetime</artifactId>
-    <version>3.0.2</version>
+    <version>3.0.3-SNAPSHOT</version>
     <name>POJava DateTime</name>
     <description>
         POJava DateTime is a simple, light-weight Java-based API for parsing and manipulating dates.
@@ -84,14 +84,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.16</version>
+                <version>2.19.1</version>
                 <configuration>
-                    <systemPropertyVariables>
-                        <includes>
-                            <include>**/*Test.java</include>
-                            <include>**/*Tester.java</include>
-                        </includes>
-                    </systemPropertyVariables>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tester.java</include>
+                    </includes>
                 </configuration>
             </plugin>
             <plugin>
@@ -146,5 +144,26 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>doclint-java8-disable</id>
+            <activation>
+                <jdk>[1.8,)</jdk>
+            </activation>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalparam>-Xdoclint:none</additionalparam>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>

--- a/src/main/java/org/pojava/datetime/CalendarSupplier.java
+++ b/src/main/java/org/pojava/datetime/CalendarSupplier.java
@@ -1,0 +1,17 @@
+package org.pojava.datetime;
+
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+/**
+ * Defines how the calendar is created to calculate times.
+ */
+public interface CalendarSupplier {
+    /**
+     * return a cleared calendar with that timezone.
+     * @param tz the timezone
+     * @return the calendar
+     */
+    Calendar getCalendar(TimeZone tz);
+}

--- a/src/main/java/org/pojava/datetime/CharPattern.java
+++ b/src/main/java/org/pojava/datetime/CharPattern.java
@@ -1,0 +1,19 @@
+package org.pojava.datetime;
+
+final class CharPattern {
+
+    private final CharPredicate[] predicates;
+
+    CharPattern(CharPredicate... predicates) {
+        this.predicates = predicates;
+    }
+
+    boolean matches(CharSequence cs, int start) {
+        if (start + predicates.length > cs.length()) return false;
+        for(int i = 0; i < predicates.length; i++) {
+            if (!predicates[i].test(cs.charAt(start + i))) return false;
+        }
+        return true;
+    }
+
+}

--- a/src/main/java/org/pojava/datetime/CharPredicate.java
+++ b/src/main/java/org/pojava/datetime/CharPredicate.java
@@ -1,0 +1,5 @@
+package org.pojava.datetime;
+
+interface CharPredicate {
+    boolean test(char c);
+}

--- a/src/main/java/org/pojava/datetime/DateTimeConfig.java
+++ b/src/main/java/org/pojava/datetime/DateTimeConfig.java
@@ -75,6 +75,8 @@ public class DateTimeConfig implements IDateTimeConfig, Serializable {
 
     private MonthMap monthMap;
 
+    private CalendarSupplier calendarSupplier = DefaultCalendarSupplier.INSTANCE;
+
     /**
      * <p>
      * Support parsing of zones unlisted in TimeZone by translating to known zones. Got a zone
@@ -277,6 +279,11 @@ public class DateTimeConfig implements IDateTimeConfig, Serializable {
         return System.currentTimeMillis();
     }
 
+    @Override
+    public CalendarSupplier getCalendarSupplier() {
+        return calendarSupplier;
+    }
+
     public static void setGlobalDefaultFromBuilder(DateTimeConfigBuilder builder) {
         globalDefault = fromBuilder(builder);
     }
@@ -295,6 +302,7 @@ public class DateTimeConfig implements IDateTimeConfig, Serializable {
         dtc.outputTimeZone = builder.getOutputTimeZone();
         dtc.tzMap.putAll(builder.getTzMap());
         dtc.tzCache.putAll(builder.getTzCache());
+        dtc.calendarSupplier = builder.getCalendarSupplier();
         dtc.validate();
         return dtc;
     }

--- a/src/main/java/org/pojava/datetime/DateTimeConfigBuilder.java
+++ b/src/main/java/org/pojava/datetime/DateTimeConfigBuilder.java
@@ -21,6 +21,7 @@ public class DateTimeConfigBuilder {
     private Locale locale = Locale.getDefault();
     private String bcPrefix = "-";
     private MonthMap monthMap;
+    private CalendarSupplier calendarSupplier = DefaultCalendarSupplier.INSTANCE;
     /**
      * <p>
      * Support parsing of zones unlisted in TimeZone by translating to known zones. Got a zone
@@ -208,5 +209,13 @@ public class DateTimeConfigBuilder {
 
     public Map<String, String> getTzMap() {
         return tzMap;
+    }
+
+    public void setCalendarSupplier(CalendarSupplier calendarSupplier) {
+        this.calendarSupplier = calendarSupplier;
+    }
+
+    public CalendarSupplier getCalendarSupplier() {
+        return calendarSupplier;
     }
 }

--- a/src/main/java/org/pojava/datetime/DefaultCalendarSupplier.java
+++ b/src/main/java/org/pojava/datetime/DefaultCalendarSupplier.java
@@ -1,0 +1,17 @@
+package org.pojava.datetime;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+
+/**
+ * Implementation of CalendarSupplier that create a new calendar every time.
+ */
+public final class DefaultCalendarSupplier implements CalendarSupplier {
+    public static final DefaultCalendarSupplier INSTANCE = new DefaultCalendarSupplier();
+    private DefaultCalendarSupplier() {
+    }
+    @Override
+    public Calendar getCalendar(TimeZone tz) {
+        return Calendar.getInstance(tz);
+    }
+}

--- a/src/main/java/org/pojava/datetime/IDateTimeConfig.java
+++ b/src/main/java/org/pojava/datetime/IDateTimeConfig.java
@@ -66,4 +66,6 @@ public interface IDateTimeConfig {
 
     public void validate();
 
+    public CalendarSupplier getCalendarSupplier();
+
 }

--- a/src/main/java/org/pojava/datetime/IsDigit.java
+++ b/src/main/java/org/pojava/datetime/IsDigit.java
@@ -1,0 +1,15 @@
+package org.pojava.datetime;
+
+/**
+ *
+ */
+final class IsDigit implements CharPredicate {
+
+    static final IsDigit INSTANCE = new IsDigit();
+
+    private IsDigit() {
+    }
+    public boolean test(char c) {
+        return Character.isDigit(c);
+    }
+}

--- a/src/main/java/org/pojava/datetime/IsEqual.java
+++ b/src/main/java/org/pojava/datetime/IsEqual.java
@@ -1,0 +1,18 @@
+package org.pojava.datetime;
+
+final class IsEqual implements  CharPredicate {
+
+    static IsEqual of(char c) {
+        return new IsEqual(c);
+    }
+
+    private final char value;
+
+    private IsEqual(char value) {
+        this.value = value;
+    }
+
+    public boolean test(char c) {
+        return this.value == c;
+    }
+}

--- a/src/main/java/org/pojava/datetime/IsSign.java
+++ b/src/main/java/org/pojava/datetime/IsSign.java
@@ -1,0 +1,13 @@
+package org.pojava.datetime;
+
+final class IsSign implements CharPredicate {
+
+    static final IsSign INSTANCE = new IsSign();
+
+    private IsSign() {
+    }
+
+    public boolean test(char c) {
+        return c == '+' || c == '-';
+    }
+}

--- a/src/main/java/org/pojava/datetime/LocalConfig.java
+++ b/src/main/java/org/pojava/datetime/LocalConfig.java
@@ -102,4 +102,9 @@ public class LocalConfig implements IDateTimeConfig {
     public void validate() {
         config.validate();
     }
+
+    @Override
+    public CalendarSupplier getCalendarSupplier() {
+        return config.getCalendarSupplier();
+    }
 }

--- a/src/main/java/org/pojava/datetime/MutableString.java
+++ b/src/main/java/org/pojava/datetime/MutableString.java
@@ -1,0 +1,242 @@
+package org.pojava.datetime;
+
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+class MutableString implements CharSequence {
+
+    private int startIndex;
+    private int endIndex;
+    private char[] charArray;
+
+
+    MutableString(String str) {
+        charArray = str.toCharArray();
+        endIndex = str.length();
+    }
+
+    private MutableString(char[] charArray, int startIndex, int endIndex) {
+        this.charArray = charArray;
+        this.endIndex = endIndex;
+        this.startIndex = startIndex;
+    }
+
+    MutableString upperCase() {
+        for(int i = startIndex; i < endIndex; i++) {
+            charArray[i] = Character.toUpperCase(charArray[i]);
+        }
+        return this;
+    }
+
+    MutableString trim() {
+        endIndex = lastNonWhiteSpacePlusOne();
+        startIndex = firstNonWhiteSpace();
+        return this;
+    }
+
+    private int lastNonWhiteSpacePlusOne() {
+        for(int i = length() - 1; i >= 0; i--) {
+            if (charAt(i) != ' ') return i + 1;
+        }
+        return startIndex;
+    }
+
+    private int firstNonWhiteSpace() {
+        for(int i = 0; i < length(); i++) {
+            if (charAt(i) != ' ') return i;
+        }
+        return endIndex;
+    }
+
+    @Override
+    public int length() {
+        return endIndex - startIndex;
+    }
+
+    @Override
+    public MutableString subSequence(int start, int end) {
+        return new MutableString(charArray, calculateIndex(start), calculateIndex(end));
+    }
+
+    @Override
+    public char charAt(int i) {
+        return charArray[calculateIndex(i)];
+    }
+
+    private int calculateIndex(int i) {
+        return i + startIndex;
+    }
+
+    boolean isDigit(int i) {
+        final char c = charAt(i);
+        return c >= '0' && c <= '9';
+    }
+
+    void setChar(int i, char c) {
+        charArray[calculateIndex(i)] = c;
+    }
+
+    @Override
+    public String toString() {
+        return new String(charArray, startIndex, endIndex - startIndex);
+    }
+
+
+    boolean onlyDigits(int start, int end) {
+        for(int i = start; i < end; i++) {
+            char c = charAt(i);
+            if (isNotDigit(c)) return false;
+        }
+        return true;
+    }
+
+    private boolean isNotDigit(char c) {
+        return c < '0' || c > '9';
+    }
+
+    int parseInt(int start, int end) {
+        if (charAt(start) == '+') {
+            start ++;
+        }
+
+        int v = 0;
+        int m = 1;
+        for(int i = start; i < end; i++) {
+            char c = charAt(i);
+            if (i == 0 && c == '-') {
+                m = -1;
+            } else if (c >= '0' && c <= '9'){
+                v = (v * 10) + (c - '0');
+            } else {
+                break;
+            }
+        }
+        return v * m;
+    }
+
+    boolean onlyDigits() {
+        return onlyDigits(0, length());
+    }
+
+    int parseInt() {
+        return parseInt(0, length());
+    }
+
+    boolean isInteger() {
+        return isInteger(0, length());
+    }
+
+    boolean isInteger(int start, int end) {
+        for(int i = start; i < end; i++) {
+            char c = charAt(i);
+            if (isNotDigit(c) && !((c == '+' || c == '-')  &&  i == 0))
+                return false;
+        }
+        return true;
+    }
+
+    boolean isAlpha(int i) {
+        char c = charAt(i);
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+    }
+
+    void add(char c, int i) {
+        i += startIndex;
+        char[] newChars = new char[charArray.length + 1];
+        System.arraycopy(charArray, 0, newChars, 0, i);
+        System.arraycopy(charArray, i, newChars, i + 1, charArray.length - i);
+        newChars[i] = c;
+        charArray = newChars;
+        endIndex ++;
+    }
+
+    int indexOf(char c) {
+        for(int i = 0; i < length(); i++) {
+            if (charAt(i) == c) return i;
+        }
+        return -1;
+    }
+
+    MutableString subSequence(int start) {
+        return subSequence(start, endIndex - startIndex);
+    }
+
+    boolean endsWith(String v) {
+        if (v.length() > length()) return false;
+        int startIndex = length() - v.length();
+        for(int i = v.length() - 1; i >= 0 ; i--) {
+            if (v.charAt(i) != charAt(startIndex + i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    List<MutableString> split(CharPredicate predicate) {
+        List<MutableString> list = new ArrayList<MutableString>(10);
+
+        int startIndex = 0;
+        boolean hasContent = false;
+        for(int i = 0; i < length(); i++) {
+            char c = charAt(i);
+            if (predicate.test(c)) {
+                if (hasContent) {
+                    list.add(subSequence(startIndex, i));
+                }
+                startIndex = i + 1;
+                hasContent = false;
+            } else {
+                hasContent = true;
+            }
+        }
+
+        if (hasContent) {
+            list.add(subSequence(startIndex, length()));
+        }
+
+        return list;
+    }
+
+    int getStartIndex() {
+        return startIndex;
+    }
+
+    int getEndIndex() {
+        return endIndex;
+    }
+
+    boolean matches(CharSequence cs) {
+        if (cs == null) {
+            return false;
+        }
+        if (cs.length() != length()) {
+            return false;
+        }
+        for(int i = 0; i < length(); i++) {
+            if (charAt(i) != cs.charAt(i)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean charSequenceEquals(CharSequence charSequence) {
+        if (charSequence.length() != length()) return false;
+        for(int i = 0; i < length(); i++) {
+            if (charSequence.charAt(i) != charAt(i)) return false;
+         }
+        return true;
+    }
+
+
+    void deleteWithArrayIndex(int startIndex, int endIndex) {
+        if (endIndex == this.endIndex) {
+            this.endIndex = startIndex;
+        } else {
+            System.arraycopy(charArray, endIndex, charArray, startIndex, charArray.length - endIndex);
+            this.endIndex = (this.endIndex - endIndex + startIndex);
+        }
+    }
+}

--- a/src/main/java/org/pojava/datetime/NotAlphaOrNumberPredicate.java
+++ b/src/main/java/org/pojava/datetime/NotAlphaOrNumberPredicate.java
@@ -1,0 +1,13 @@
+package org.pojava.datetime;
+
+final class NotAlphaOrNumberPredicate implements CharPredicate {
+
+    static final NotAlphaOrNumberPredicate INSTANCE = new NotAlphaOrNumberPredicate();
+
+    private NotAlphaOrNumberPredicate() {
+    }
+
+    public boolean test(char c) {
+        return !Character.isLetter(c) && NotNumericPredicate.isNotDigit(c);
+    }
+}

--- a/src/main/java/org/pojava/datetime/NotNumericPredicate.java
+++ b/src/main/java/org/pojava/datetime/NotNumericPredicate.java
@@ -1,0 +1,17 @@
+package org.pojava.datetime;
+
+final class NotNumericPredicate implements CharPredicate {
+
+    static final NotNumericPredicate INSTANCE = new NotNumericPredicate();
+
+    private NotNumericPredicate() {
+    }
+
+    public boolean test(char c) {
+        return isNotDigit(c);
+    }
+
+    static boolean isNotDigit(char c) {
+        return c < '0' || c > '9';
+    }
+}

--- a/src/main/java/org/pojava/datetime/ThreadLocalCalendarSupplier.java
+++ b/src/main/java/org/pojava/datetime/ThreadLocalCalendarSupplier.java
@@ -1,0 +1,26 @@
+package org.pojava.datetime;
+
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+/**
+ * Implementation of CalendarSupplier that caches the Calendar in a
+ * thread local variable.
+ */
+public final class ThreadLocalCalendarSupplier implements CalendarSupplier {
+    private final ThreadLocal<Calendar> calendarThreadLocal = new ThreadLocal<Calendar>() {
+        @Override
+        protected Calendar initialValue() {
+            return Calendar.getInstance();
+        }
+    };
+
+    @Override
+    public Calendar getCalendar(TimeZone tz) {
+        final Calendar calendar = calendarThreadLocal.get();
+        calendar.clear();
+        calendar.setTimeZone(tz);
+        return calendar;
+    }
+}

--- a/src/main/java/org/pojava/datetime/Tm.java
+++ b/src/main/java/org/pojava/datetime/Tm.java
@@ -213,8 +213,12 @@ public class Tm {
      * @return time in milliseconds since epoch, UTC.
      */
     public static long calcTime(int year, int month, int day) {
+        return calcTime(year, month, day, DateTimeConfig.getGlobalDefault().getCalendarSupplier());
+    }
+
+    public static long calcTime(int year, int month, int day, CalendarSupplier calendarSupplier) {
         IDateTimeConfig config = DateTimeConfig.getGlobalDefault();
-        return calcTime(year, month, day, 0, 0, 0, 0, config.getOutputTimeZone());
+        return calcTime(year, month, day, 0, 0, 0, 0, config.getOutputTimeZone(), calendarSupplier);
     }
 
     /**
@@ -232,8 +236,13 @@ public class Tm {
      */
     public static long calcTime(int year, int month, int day, int hour, int min, int sec,
                                 int milli) {
+        return calcTime(year, month, day, hour, min, sec, milli,
+                DateTimeConfig.getGlobalDefault().getCalendarSupplier());
+    }
+    public static long calcTime(int year, int month, int day, int hour, int min, int sec,
+                                int milli, CalendarSupplier calendarSupplier) {
         IDateTimeConfig config = DateTimeConfig.getGlobalDefault();
-        return calcTime(year, month, day, hour, min, sec, milli, config.getOutputTimeZone());
+        return calcTime(year, month, day, hour, min, sec, milli, config.getOutputTimeZone(), calendarSupplier);
     }
 
     /**
@@ -251,7 +260,13 @@ public class Tm {
      */
     public static long calcTime(int year, int month, int day, int hour, int min, int sec,
                                 int milli, TimeZone tz) {
-        Calendar cal = Calendar.getInstance(tz);
+        return calcTime(year, month, day, hour, min, sec, milli, tz,
+                DateTimeConfig.getGlobalDefault().getCalendarSupplier());
+    }
+
+    public static long calcTime(int year, int month, int day, int hour, int min, int sec,
+                                int milli, TimeZone tz, CalendarSupplier calendarSupplier) {
+        Calendar cal = calendarSupplier.getCalendar(tz);
         cal.set(Calendar.YEAR, year);
         cal.set(Calendar.MONTH, month - 1);
         cal.set(Calendar.DAY_OF_MONTH, day);

--- a/src/test/java/org/pojava/datetime/CharPatternTest.java
+++ b/src/test/java/org/pojava/datetime/CharPatternTest.java
@@ -1,0 +1,21 @@
+package org.pojava.datetime;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class CharPatternTest {
+    @Test
+    public void matches() throws Exception {
+
+        CharPattern charPattern = new CharPattern(IsEqual.of('c'), IsDigit.INSTANCE);
+
+        assertFalse(charPattern.matches("ddc9ll", 0));
+        assertTrue(charPattern.matches("ddc9ll", 2));
+        assertFalse(charPattern.matches("c", 0));
+        assertFalse(charPattern.matches("cl9", 0));
+
+    }
+
+}

--- a/src/test/java/org/pojava/datetime/MonthMapTester.java
+++ b/src/test/java/org/pojava/datetime/MonthMapTester.java
@@ -79,7 +79,7 @@ public class MonthMapTester extends TestCase {
         assertEquals(4, monthMap.monthIndex("magg.").intValue());
         assertEquals(5, monthMap.monthIndex("giugno").intValue());
         assertEquals(6, monthMap.monthIndex("luglio").intValue());
-        assertEquals(7, monthMap.monthIndex("ag.").intValue());
+        assertEquals(7, monthMap.monthIndex("ago.").intValue());
         assertEquals(8, monthMap.monthIndex("sett.").intValue());
         assertEquals(9, monthMap.monthIndex("ott.").intValue());
         assertEquals(10, monthMap.monthIndex("nov.").intValue());

--- a/src/test/java/org/pojava/datetime/MutableStringTest.java
+++ b/src/test/java/org/pojava/datetime/MutableStringTest.java
@@ -1,0 +1,137 @@
+package org.pojava.datetime;
+
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class MutableStringTest {
+
+    static final String sampleString = "  abCdef123 ";
+    @Test
+    public void toUpperCase() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        ms.upperCase();
+        assertEquals(sampleString.toUpperCase(), ms.toString());
+
+        MutableString ms2 = new MutableString(sampleString);
+        ms2.subSequence(3, 4).upperCase();
+
+        assertEquals("  aBCdef123 ", ms2.toString());
+    }
+
+    @Test
+    public void setChar() {
+        MutableString ms = new MutableString(sampleString);
+        ms.setChar(3, 'z');
+        assertEquals('z', ms.charAt(3));
+
+        MutableString subSequence = ms.subSequence(5);
+        subSequence.setChar(3, 'z');
+        assertEquals('z', subSequence.charAt(3));
+
+    }
+
+    @Test
+    public void trim() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        ms.trim();
+        assertEquals("abCdef123", ms.toString());
+    }
+
+    @Test
+    public void isDigit() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+
+        for(int i = 0; i < sampleString.length(); i++) {
+            char sc = sampleString.charAt(i);
+            char msc = ms.charAt(i);
+            assertEquals(sc, msc);
+            assertEquals(Character.digit(sc, 10) >= 0, ms.isDigit(i));
+        }
+    }
+
+    @Test
+    public void onlyDigits() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        assertFalse(ms.onlyDigits());
+        assertTrue(ms.subSequence(8, 11).onlyDigits());
+    }
+
+    @Test
+    public void parseInt() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        assertEquals(123, ms.parseInt(8, 11));
+        assertEquals(123, ms.subSequence(8, 11).parseInt());
+
+
+        assertEquals(12, new MutableString("12ab").parseInt());
+        assertEquals(0, new MutableString("q12").parseInt());
+    }
+
+
+    @Test
+    public void isInteger() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        assertFalse(ms.isInteger());
+        assertTrue(ms.isInteger(8, 11));
+        assertTrue(ms.subSequence(8, 11).isInteger());
+    }
+
+    @Test
+    public void isAlpha() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        assertFalse(ms.isAlpha(0));
+        assertTrue(ms.isAlpha(3));
+        assertFalse(ms.isAlpha(8));
+    }
+
+    @Test
+    public void add() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        ms.add('a', 3);
+        assertEquals("  aabCdef123 ", ms.toString());
+    }
+
+    @Test
+    public void indexOf() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        assertEquals(4,  ms.indexOf('C'));
+        assertEquals(-1,  ms.indexOf('Z'));
+    }
+
+
+    @Test
+    public void endsWith() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        assertTrue(ms.endsWith("123 "));
+        assertFalse(ms.endsWith(sampleString + "ssss"));
+        assertFalse(ms.endsWith("1234"));
+    }
+
+    @Test
+    public void split() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        final List<MutableString> split = ms.split(new CharPredicate() {
+            @Override
+            public boolean test(char c) {
+                return Character.isLetter(c);
+            }
+        });
+
+        assertEquals(2, split.size());
+        assertEquals("  ", split.get(0).toString());
+        assertEquals("123 ", split.get(1).toString());
+    }
+
+    @Test
+    public void deleteWithArrayIndex() throws Exception {
+        MutableString ms = new MutableString(sampleString);
+        MutableString ms2 = ms.subSequence(3, 7);
+        ms2.deleteWithArrayIndex(4, 5);
+        assertEquals("  abdef123  ", ms.toString());
+        assertEquals("bde", ms2.toString());
+    }
+
+}


### PR DESCRIPTION
Use MutableString to avoid regex and string creations, allow for ThreadLocal Calendar Supplier.

before
     Benchmark                    Mode  Samples       Score   Units
     c.r.DateTimeParser.parse    thrpt       20  159 128.064   ops/s

After
No thread local
c.r.DateTimeParser.parse    thrpt       20       837 832.628     ops/s

with thread local
     c.r.DateTimeParser.parse    thrpt       20  979 818.784    ops/s
